### PR TITLE
Added Docker and Docker Compose Installation Instructions  For Ubuntu and Linux Users 

### DIFF
--- a/documentation/docs/installation-ubuntu.md
+++ b/documentation/docs/installation-ubuntu.md
@@ -42,47 +42,47 @@ nvm install node
 
 <br/>
 
-Here’s the guide formatted in Markdown for better readability:
-
----
+ 
 
 ## **2. Install Docker**
 
-### **Using Repository and GPG Key**
-
-1. **Add Docker’s official GPG key and repository:**
+1. **Update System Packages:**
 
    ```bash
    sudo apt-get update
-   sudo apt-get install -y ca-certificates curl
-   sudo install -m 0755 -d /etc/apt/keyrings
-   sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-   sudo chmod a+r /etc/apt/keyrings/docker.asc
+   sudo apt-get install -y ca-certificates curl gnupg
    ```
 
-2. **Add Docker repository to Apt sources:**
+2. **Add Docker's Official GPG Key:**
+
+   ```bash
+   sudo install -m 0755 -d /etc/apt/keyrings
+   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+   sudo chmod a+r /etc/apt/keyrings/docker.gpg
+   ```
+
+3. **Set Up Docker Repository:**
 
    ```bash
    echo \
-   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-   $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
    ```
 
-3. **Update your package list:**
+4. **Install Docker:**
 
    ```bash
    sudo apt-get update
-   ```
-
-4. **Install Docker packages:**
-
-   ```bash
    sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
    ```
 
----
+5. **Verify Docker Installation:**
 
+   ```bash
+   docker --version
+   ```
+
+---
 ### **Using Snap**
 
 1. **Install Docker using Snap:**
@@ -105,24 +105,23 @@ Here’s the guide formatted in Markdown for better readability:
 
 ## **3. Install Docker Compose**
 
-### **Using Repository**
-
-1. **Download and install Docker Compose:**
+1. **Download the Latest Version of Docker Compose:**
 
    ```bash
-   sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+   mkdir -p ~/.docker/cli-plugins/
+   curl -SL https://github.com/docker/compose/releases/download/v2.29.7/docker-compose-linux-$(uname -m) -o ~/.docker/cli-plugins/docker-compose
    ```
 
-2. **Set correct permissions:**
+2. **Set Executable Permissions:**
 
    ```bash
-   sudo chmod +x /usr/local/bin/docker-compose
+   chmod +x ~/.docker/cli-plugins/docker-compose
    ```
 
-3. **Verify the installation:**
+3. **Verify Docker Compose Installation:**
 
    ```bash
-   docker-compose --version
+   docker compose version
    ```
 
 ---

--- a/documentation/docs/installation-ubuntu.md
+++ b/documentation/docs/installation-ubuntu.md
@@ -42,65 +42,108 @@ nvm install node
 
 <br/>
 
-### 2. **Install Docker**
+Here’s the guide formatted in Markdown for better readability:
 
-- **Add Docker's official GPG key and repository:**
+---
 
-```
-sudo apt-get update sudo apt-get install -y ca-certificates curl sudo install -m 0755 -d /etc/apt/keyrings sudo curl -fsSL [https://download.docker.com/linux/ubuntu/gpg](https://download.docker.com/linux/ubuntu/gpg) -o /etc/apt/keyrings/docker.asc sudo chmod a+r /etc/apt/keyrings/docker.asc
-```
+## **2. Install Docker**
+
+### **Using Repository and GPG Key**
+
+1. **Add Docker’s official GPG key and repository:**
+
+   ```bash
+   sudo apt-get update
+   sudo apt-get install -y ca-certificates curl
+   sudo install -m 0755 -d /etc/apt/keyrings
+   sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+   sudo chmod a+r /etc/apt/keyrings/docker.asc
+   ```
+
+2. **Add Docker repository to Apt sources:**
+
+   ```bash
+   echo \
+   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+   $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+   ```
+
+3. **Update your package list:**
+
+   ```bash
+   sudo apt-get update
+   ```
+
+4. **Install Docker packages:**
+
+   ```bash
+   sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+   ```
+
+---
+
+### **Using Snap**
+
+1. **Install Docker using Snap:**
+
+   ```bash
+   sudo snap install docker
+   ```
+
+   This installs the Snap version of Docker, typically updated to version `27.2.0` or later.
+
+## **Verify Installations**
+
+**Check Docker version:**
+
+   ```bash
+   docker --version
+   ```
 
 <br/>
 
-- **Add the Docker repository to Apt sources:**
+## **3. Install Docker Compose**
 
-```
-echo \ "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] [https://download.docker.com/linux/ubuntu](https://download.docker.com/linux/ubuntu) \ $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \ sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-```
+### **Using Repository**
 
-<br/>
+1. **Download and install Docker Compose:**
 
-- **Update your package list:**
+   ```bash
+   sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+   ```
 
-```
-sudo apt-get update
-```
+2. **Set correct permissions:**
 
-<br/>
+   ```bash
+   sudo chmod +x /usr/local/bin/docker-compose
+   ```
 
-- **Install Docker packages:**
+3. **Verify the installation:**
 
-```
-sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-```
+   ```bash
+   docker-compose --version
+   ```
 
-<br/>
+---
 
-### 3. **Install Docker Compose**
+### **Using Snap**
 
-<br/>
+To install Docker Compose directly using Apt, you can use the following command:
 
-- **Download and install Docker Compose:**
-
-```
-sudo curl -L "[https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname](https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname) -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+```bash
+sudo apt install docker-compose
 ```
 
-<br/>
+---
 
-- **Set the correct permissions:**
+## **Verify Installations**
 
-```
-sudo chmod +x /usr/local/bin/docker-compose
-```
+**Check Docker Compose version:**
 
-<br/>
-
-- **Verify the installation:**
-
-```
-docker-compose --version
-```
+   ```bash
+   docker-compose --version
+   ```
 
 <br/>
 
@@ -141,19 +184,19 @@ After installing the XEST CLI globally, you can now bootstrap your API.
 In order to create your API, you need to run the following commmand:
 
 ```bash
-$ xx [project-name]
+xx [project-name]
 ```
 
 With one simple command, you will be installing all the necessary packages, utils, middlewares and required modules will be created for you. Have a look at the created directory.
 
 ```bash
-$ cd project-name
+cd project-name
 ```
 
 to start your Xest API, run
 
 ```bash
-$ xx run
+xx run
 ```
 
 Et voila! You're ready to Xest :)


### PR DESCRIPTION

This pull request introduces a detailed guide for installing Docker and Docker Compose on Ubuntu. The guide covers two installation methods:  

1. **Using Docker’s Official Repository and GPG Key**  
2. **Using Snap Package Manager**  

The instructions ensure flexibility for users to choose their preferred method based on system compatibility and package availability. Key components include:  
- Adding Docker’s official GPG key and repository.  
- Installing Docker packages such as `docker-ce`, `docker-ce-cli`, and Docker Compose plugin.  
- Downloading and setting up Docker Compose manually.  
- Alternative installation of Docker and Docker Compose using Snap or Apt.  

Additionally, verification steps are provided to confirm successful installations.  

---

### **Changes Introduced**  
- Added Markdown-formatted instructions for installing Docker and Docker Compose.
- Included multiple installation methods: repository-based, Snap, and direct Apt installation.
- Enhanced clarity with verification commands and alternative approaches.

---

### **How to Test**  
1. Follow the steps in the guide to install Docker and Docker Compose.  
2. Verify installation by running:  
   ```bash
   docker --version
   docker-compose --version
   ```

---

 